### PR TITLE
feat(textbot): implement `!` command support

### DIFF
--- a/textbot/get.go
+++ b/textbot/get.go
@@ -126,7 +126,6 @@ func (t textBot) getById(args []string) (int64, types.MusicRecord, error) {
 
 	recordID, err := strconv.ParseInt(args[0], 10, 64)
 	if err != nil {
-		log.Printf("%T", err)
 		if _, ok := err.(*strconv.NumError); ok {
 			// not a number
 			return 0, types.MusicRecord{}, nil

--- a/textbot/textbot_test.go
+++ b/textbot/textbot_test.go
@@ -27,6 +27,18 @@ func TestParseArgs(t *testing.T) {
 			msg:  "test",
 			args: []string{"test"},
 		},
+		{
+			msg:  "!",
+			args: []string{"!"},
+		},
+		{
+			msg:  "!  ",
+			args: []string{"!"},
+		},
+		{
+			msg:  "  ! ",
+			args: []string{"!"},
+		},
 	}
 	for _, test := range tests {
 		t.Run(


### PR DESCRIPTION
This command repeat the last command, with all its parameters.