### PR TITLE
fix(cmd/cli): print the results count in the tags list

### DIFF
--- a/cmd/cli/print.go
+++ b/cmd/cli/print.go
@@ -25,7 +25,15 @@ func printMusicRecord(result textbot.Result) string {
 	for _, tag := range result.Tags {
 		tags = append(tags, "#"+tag)
 	}
-	fmt.Fprintln(&b, strings.Join(tags, " "))
+	fmt.Fprint(&b, strings.Join(tags, " "))
+
+	if result.Count == 1 {
+		fmt.Fprintln(&b, " [1 résultat]")
+	} else if result.Count > 1 {
+		fmt.Fprintf(&b, " [%d résultats]\n", result.Count)
+	} else {
+		fmt.Fprintln(&b)
+	}
 	fmt.Fprintln(&b, result.Count)
 
 	return b.String()


### PR DESCRIPTION
This is a hack to make the Perl bot output this counter. The Perl bot ignores the last line with the counter.