### PR TITLE
chore(repository/mariadb): use the new sql.Null generic type

### DIFF
--- a/playbot/search_music_record.go
+++ b/playbot/search_music_record.go
@@ -19,7 +19,7 @@ type Search struct {
 
 // Search for a music record.
 //
-// The first time a search is done in a channel, its parameters and context will be
+// The first time a search is done in a channel, its parameters and context are
 // saved. When doing another search in the same channel, if the parameters are the
 // same as the previous ones, it returns the next result for the previous search.
 // If the parameters are different from the previous ones, the previous search is
@@ -30,11 +30,11 @@ type Search struct {
 // must look at the count returned value. If it is zero it means there is no result,
 // else it means all results have been consumed.
 //
-// searchCtx is the context used for the whole search. If the search is consumed again,
-// the initial searchCtx given when starting the search will be used and the current one
+// search.Ctx is the context used for the whole search. If the search is consumed again,
+// the initial search.Ctx given when starting the search will be used and the current one
 // will be ignored. If this context is canceled, the whole search is discarded and a new
 // one is started.
-// resultCtx is the context used to return the result. If the context is canceled no
+// ctx is the context used to return the result. If the context is canceled no
 // result is returned, but the search is kept and can be consumed again.
 func (p *Playbot) SearchMusicRecord(
 	ctx context.Context,

--- a/repository/mariadb/get_music_record.go
+++ b/repository/mariadb/get_music_record.go
@@ -25,8 +25,8 @@ func (r mariaDbRepository) GetMusicRecord(musicRecordId int64) (types.MusicRecor
 	)
 
 	var title, url, source string
-	var recordID, sender sql.NullString
-	var duration sql.NullInt64
+	var recordID, sender sql.Null[string]
+	var duration sql.Null[int64]
 	err := row.Scan(&sender, &title, &url, &duration, &recordID, &source)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -37,10 +37,10 @@ func (r mariaDbRepository) GetMusicRecord(musicRecordId int64) (types.MusicRecor
 	}
 
 	record := types.MusicRecord{
-		Band:     types.Band{Name: sender.String},
-		Duration: time.Duration(duration.Int64 * int64(time.Second)),
+		Band:     types.Band{Name: sender.V},
+		Duration: time.Duration(duration.V * int64(time.Second)),
 		Name:     title,
-		RecordId: recordID.String,
+		RecordId: recordID.V,
 		Source:   source,
 		Url:      url,
 	}

--- a/repository/mariadb/mariadb.go
+++ b/repository/mariadb/mariadb.go
@@ -35,6 +35,10 @@ func New(user string, password string, host string, dbname string) (mariaDbRepos
 		return mariaDbRepository{}, err
 	}
 
+	return NewFromDB(db)
+}
+
+func NewFromDB(db *sql.DB) (mariaDbRepository, error) {
 	if err := db.Ping(); err != nil {
 		return mariaDbRepository{}, err
 	}

--- a/repository/mariadb/search_music_record.go
+++ b/repository/mariadb/search_music_record.go
@@ -46,8 +46,8 @@ func (r mariaDbRepository) SearchMusicRecord(
 		for rows.Next() {
 			var id int64
 			var title, url, source string
-			var recordID, sender sql.NullString
-			var duration sql.NullInt64
+			var recordID, sender sql.Null[string]
+			var duration sql.Null[int64]
 			err := rows.Scan(&id, &sender, &title, &url, &duration, &recordID, &source)
 			if err != nil {
 				log.Printf("Error while fetching rows after search: %s", err)
@@ -57,10 +57,10 @@ func (r mariaDbRepository) SearchMusicRecord(
 			searchResult := searchResult{
 				id,
 				types.MusicRecord{
-					Band:     types.Band{Name: sender.String},
-					Duration: time.Duration(duration.Int64 * int64(time.Second)),
+					Band:     types.Band{Name: sender.V},
+					Duration: time.Duration(duration.V * int64(time.Second)),
 					Name:     title,
-					RecordId: recordID.String,
+					RecordId: recordID.V,
 					Source:   source,
 					Url:      url,
 				},


### PR DESCRIPTION
New in Go 1.22.

Also adds two tests to ensure the code manage nullable columns.