### PR TITLE
chore(irc): fix call to PrintfLine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ generate:
 
 style:
 	go fmt ./...
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1 run
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1 run
 
 test:
 	go test ./...

--- a/irc/irc.go
+++ b/irc/irc.go
@@ -44,7 +44,7 @@ func New(config Config) (*Conn, error) {
 
 func (i *Conn) sendRaw(msg string) error {
 	time.Sleep(time.Until(i.throttleDeadline))
-	err := i.writer.PrintfLine(msg)
+	err := i.writer.PrintfLine("%s", msg)
 	i.throttleDeadline = time.Now().Add(500 * time.Millisecond)
 
 	if err != nil {


### PR DESCRIPTION
`go vet` (used by golang-ci) is complaining that we call a "printf" method with a unique parameter and so no format. In this case he wants the parameter to be a constant, but here we can't. So we use a dumb format string to make it happy.